### PR TITLE
Added option handle transfers

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -101,7 +101,7 @@ class Transaction
      * @param $receiver_params
      * @return $this
      */
-    public function transfer($amount, $receiver, $currency = null, $receiver_params = null)
+    public function transfer($amount, $receiver, $currency = null, $receiver_params = [])
     {
         array_push($this->transfers, [
             'amount' => $amount,


### PR DESCRIPTION
Allow multiple transfers like the example https://stripe.com/docs/connect/charges-transfers#collecting-fees.

## Option 1

```php
StripeConnect::transaction($token)
    ->amount(10000, 'usd')
    ->fee(7000) // Fee for the account of the api credentials
    ->transfer($driver, 2000)
    ->from($customer)
    ->to($vendor)
    ->create();
```

## Option 2

```php
StripeConnect::transaction($token)
    ->amount(10000, 'usd')
    ->transfer($restaurant, 7000)
    ->transfer($driver, 2000)
    ->from($customer)
    ->to($vendor)
    ->create();
```

## Sending a transfer in another currency

```php
StripeConnect::transaction($token)
    ->amount(10000, 'usd')
    ->transfer($driver, 2000, 'cad')
    ->from($customer)
    ->to($vendor)
    ->create();
```